### PR TITLE
Switch from evaluating the Reminders when the addon loads to using timers

### DIFF
--- a/Libs/AceTimer-3.0/AceTimer-3.0.lua
+++ b/Libs/AceTimer-3.0/AceTimer-3.0.lua
@@ -1,0 +1,278 @@
+--- **AceTimer-3.0** provides a central facility for registering timers.
+-- AceTimer supports one-shot timers and repeating timers. All timers are stored in an efficient
+-- data structure that allows easy dispatching and fast rescheduling. Timers can be registered
+-- or canceled at any time, even from within a running timer, without conflict or large overhead.\\
+-- AceTimer is currently limited to firing timers at a frequency of 0.01s as this is what the WoW timer API
+-- restricts us to.
+--
+-- All `:Schedule` functions will return a handle to the current timer, which you will need to store if you
+-- need to cancel the timer you just registered.
+--
+-- **AceTimer-3.0** can be embeded into your addon, either explicitly by calling AceTimer:Embed(MyAddon) or by
+-- specifying it as an embeded library in your AceAddon. All functions will be available on your addon object
+-- and can be accessed directly, without having to explicitly call AceTimer itself.\\
+-- It is recommended to embed AceTimer, otherwise you'll have to specify a custom `self` on all calls you
+-- make into AceTimer.
+-- @class file
+-- @name AceTimer-3.0
+-- @release $Id: AceTimer-3.0.lua 1170 2018-03-29 17:38:58Z funkydude $
+
+local MAJOR, MINOR = "AceTimer-3.0", 17 -- Bump minor on changes
+local AceTimer, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
+
+if not AceTimer then return end -- No upgrade needed
+AceTimer.activeTimers = AceTimer.activeTimers or {} -- Active timer list
+local activeTimers = AceTimer.activeTimers -- Upvalue our private data
+
+-- Lua APIs
+local type, unpack, next, error, select = type, unpack, next, error, select
+-- WoW APIs
+local GetTime, C_TimerAfter = GetTime, C_Timer.After
+
+local function new(self, loop, func, delay, ...)
+	if delay < 0.01 then
+		delay = 0.01 -- Restrict to the lowest time that the C_Timer API allows us
+	end
+
+	local timer = {
+		object = self,
+		func = func,
+		looping = loop,
+		argsCount = select("#", ...),
+		delay = delay,
+		ends = GetTime() + delay,
+		...
+	}
+
+	activeTimers[timer] = timer
+
+	-- Create new timer closure to wrap the "timer" object
+	timer.callback = function()
+		if not timer.cancelled then
+			if type(timer.func) == "string" then
+				-- We manually set the unpack count to prevent issues with an arg set that contains nil and ends with nil
+				-- e.g. local t = {1, 2, nil, 3, nil} print(#t) will result in 2, instead of 5. This fixes said issue.
+				timer.object[timer.func](timer.object, unpack(timer, 1, timer.argsCount))
+			else
+				timer.func(unpack(timer, 1, timer.argsCount))
+			end
+
+			if timer.looping and not timer.cancelled then
+				-- Compensate delay to get a perfect average delay, even if individual times don't match up perfectly
+				-- due to fps differences
+				local time = GetTime()
+				local delay = timer.delay - (time - timer.ends)
+				-- Ensure the delay doesn't go below the threshold
+				if delay < 0.01 then delay = 0.01 end
+				C_TimerAfter(delay, timer.callback)
+				timer.ends = time + delay
+			else
+				activeTimers[timer.handle or timer] = nil
+			end
+		end
+	end
+
+	C_TimerAfter(delay, timer.callback)
+	return timer
+end
+
+--- Schedule a new one-shot timer.
+-- The timer will fire once in `delay` seconds, unless canceled before.
+-- @param callback Callback function for the timer pulse (funcref or method name).
+-- @param delay Delay for the timer, in seconds.
+-- @param ... An optional, unlimited amount of arguments to pass to the callback function.
+-- @usage
+-- MyAddOn = LibStub("AceAddon-3.0"):NewAddon("MyAddOn", "AceTimer-3.0")
+--
+-- function MyAddOn:OnEnable()
+--   self:ScheduleTimer("TimerFeedback", 5)
+-- end
+--
+-- function MyAddOn:TimerFeedback()
+--   print("5 seconds passed")
+-- end
+function AceTimer:ScheduleTimer(func, delay, ...)
+	if not func or not delay then
+		error(MAJOR..": ScheduleTimer(callback, delay, args...): 'callback' and 'delay' must have set values.", 2)
+	end
+	if type(func) == "string" then
+		if type(self) ~= "table" then
+			error(MAJOR..": ScheduleTimer(callback, delay, args...): 'self' - must be a table.", 2)
+		elseif not self[func] then
+			error(MAJOR..": ScheduleTimer(callback, delay, args...): Tried to register '"..func.."' as the callback, but it doesn't exist in the module.", 2)
+		end
+	end
+	return new(self, nil, func, delay, ...)
+end
+
+--- Schedule a repeating timer.
+-- The timer will fire every `delay` seconds, until canceled.
+-- @param callback Callback function for the timer pulse (funcref or method name).
+-- @param delay Delay for the timer, in seconds.
+-- @param ... An optional, unlimited amount of arguments to pass to the callback function.
+-- @usage
+-- MyAddOn = LibStub("AceAddon-3.0"):NewAddon("MyAddOn", "AceTimer-3.0")
+--
+-- function MyAddOn:OnEnable()
+--   self.timerCount = 0
+--   self.testTimer = self:ScheduleRepeatingTimer("TimerFeedback", 5)
+-- end
+--
+-- function MyAddOn:TimerFeedback()
+--   self.timerCount = self.timerCount + 1
+--   print(("%d seconds passed"):format(5 * self.timerCount))
+--   -- run 30 seconds in total
+--   if self.timerCount == 6 then
+--     self:CancelTimer(self.testTimer)
+--   end
+-- end
+function AceTimer:ScheduleRepeatingTimer(func, delay, ...)
+	if not func or not delay then
+		error(MAJOR..": ScheduleRepeatingTimer(callback, delay, args...): 'callback' and 'delay' must have set values.", 2)
+	end
+	if type(func) == "string" then
+		if type(self) ~= "table" then
+			error(MAJOR..": ScheduleRepeatingTimer(callback, delay, args...): 'self' - must be a table.", 2)
+		elseif not self[func] then
+			error(MAJOR..": ScheduleRepeatingTimer(callback, delay, args...): Tried to register '"..func.."' as the callback, but it doesn't exist in the module.", 2)
+		end
+	end
+	return new(self, true, func, delay, ...)
+end
+
+--- Cancels a timer with the given id, registered by the same addon object as used for `:ScheduleTimer`
+-- Both one-shot and repeating timers can be canceled with this function, as long as the `id` is valid
+-- and the timer has not fired yet or was canceled before.
+-- @param id The id of the timer, as returned by `:ScheduleTimer` or `:ScheduleRepeatingTimer`
+function AceTimer:CancelTimer(id)
+	local timer = activeTimers[id]
+
+	if not timer then
+		return false
+	else
+		timer.cancelled = true
+		activeTimers[id] = nil
+		return true
+	end
+end
+
+--- Cancels all timers registered to the current addon object ('self')
+function AceTimer:CancelAllTimers()
+	for k,v in next, activeTimers do
+		if v.object == self then
+			AceTimer.CancelTimer(self, k)
+		end
+	end
+end
+
+--- Returns the time left for a timer with the given id, registered by the current addon object ('self').
+-- This function will return 0 when the id is invalid.
+-- @param id The id of the timer, as returned by `:ScheduleTimer` or `:ScheduleRepeatingTimer`
+-- @return The time left on the timer.
+function AceTimer:TimeLeft(id)
+	local timer = activeTimers[id]
+	if not timer then
+		return 0
+	else
+		return timer.ends - GetTime()
+	end
+end
+
+
+-- ---------------------------------------------------------------------
+-- Upgrading
+
+-- Upgrade from old hash-bucket based timers to C_Timer.After timers.
+if oldminor and oldminor < 10 then
+	-- disable old timer logic
+	AceTimer.frame:SetScript("OnUpdate", nil)
+	AceTimer.frame:SetScript("OnEvent", nil)
+	AceTimer.frame:UnregisterAllEvents()
+	-- convert timers
+	for object,timers in next, AceTimer.selfs do
+		for handle,timer in next, timers do
+			if type(timer) == "table" and timer.callback then
+				local newTimer
+				if timer.delay then
+					newTimer = AceTimer.ScheduleRepeatingTimer(timer.object, timer.callback, timer.delay, timer.arg)
+				else
+					newTimer = AceTimer.ScheduleTimer(timer.object, timer.callback, timer.when - GetTime(), timer.arg)
+				end
+				-- Use the old handle for old timers
+				activeTimers[newTimer] = nil
+				activeTimers[handle] = newTimer
+				newTimer.handle = handle
+			end
+		end
+	end
+	AceTimer.selfs = nil
+	AceTimer.hash = nil
+	AceTimer.debug = nil
+elseif oldminor and oldminor < 17 then
+	-- Upgrade from old animation based timers to C_Timer.After timers.
+	AceTimer.inactiveTimers = nil
+	AceTimer.frame = nil
+	local oldTimers = AceTimer.activeTimers
+	-- Clear old timer table and update upvalue
+	AceTimer.activeTimers = {}
+	activeTimers = AceTimer.activeTimers
+	for handle, timer in next, oldTimers do
+		local newTimer
+		-- Stop the old timer animation
+		local duration, elapsed = timer:GetDuration(), timer:GetElapsed()
+		timer:GetParent():Stop()
+		if timer.looping then
+			newTimer = AceTimer.ScheduleRepeatingTimer(timer.object, timer.func, duration, unpack(timer.args, 1, timer.argsCount))
+		else
+			newTimer = AceTimer.ScheduleTimer(timer.object, timer.func, duration - elapsed, unpack(timer.args, 1, timer.argsCount))
+		end
+		-- Use the old handle for old timers
+		activeTimers[newTimer] = nil
+		activeTimers[handle] = newTimer
+		newTimer.handle = handle
+	end
+
+	-- Migrate transitional handles
+	if oldminor < 13 and AceTimer.hashCompatTable then
+		for handle, id in next, AceTimer.hashCompatTable do
+			local t = activeTimers[id]
+			if t then
+				activeTimers[id] = nil
+				activeTimers[handle] = t
+				t.handle = handle
+			end
+		end
+		AceTimer.hashCompatTable = nil
+	end
+end
+
+-- ---------------------------------------------------------------------
+-- Embed handling
+
+AceTimer.embeds = AceTimer.embeds or {}
+
+local mixins = {
+	"ScheduleTimer", "ScheduleRepeatingTimer",
+	"CancelTimer", "CancelAllTimers",
+	"TimeLeft"
+}
+
+function AceTimer:Embed(target)
+	AceTimer.embeds[target] = true
+	for _,v in next, mixins do
+		target[v] = AceTimer[v]
+	end
+	return target
+end
+
+-- AceTimer:OnEmbedDisable(target)
+-- target (object) - target object that AceTimer is embedded in.
+--
+-- cancel all timers registered for the object
+function AceTimer:OnEmbedDisable(target)
+	target:CancelAllTimers()
+end
+
+for addon in next, AceTimer.embeds do
+	AceTimer:Embed(addon)
+end

--- a/Libs/AceTimer-3.0/AceTimer-3.0.xml
+++ b/Libs/AceTimer-3.0/AceTimer-3.0.xml
@@ -1,0 +1,4 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+	<Script file="AceTimer-3.0.lua"/>
+</Ui>

--- a/README.md
+++ b/README.md
@@ -41,11 +41,13 @@ class, profession, and name only support equals.  level and ilevel support equal
 
 ## CAVEATS
 
-* Right now the processing of reminders is (mainly) triggered by a UI load which means either when your character loads or you manually run `/reload` in the console.  This means if you have a reminder that should go off and you're still logged in, it won't go off.  I hope to change that someday.
 * Since comma is used as the separator internally, commas are stripped out of your reminder message and value text
 
 ## TODO
 
+* Make sure Reminders don't popup while in combat
+* Move Reminder popup off to the side
+* Make Reminder popup moveable
 * Implement "not equal to" operation
 * Initially sort the reminder list by some order
 * Allow specific recipes/spells condition

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ class, profession, and name only support equals.  level and ilevel support equal
 
 ## TODO
 
-* Look into changing reminder checks to event/timer-based instead of on addon load.
 * Implement "not equal to" operation
 * Initially sort the reminder list by some order
 * Allow specific recipes/spells condition

--- a/Reminders.toc
+++ b/Reminders.toc
@@ -1,9 +1,10 @@
 ## Interface: 80000
 ## Title: Reminders
+## Notes: Set up periodic reminders
 ## Author: pcg79
 ## SavedVariables: RemindersDBG
 ## SavedVariablesPerCharacter: RemindersDBPC
-## Version: 8.0.1
+## Version: 8.0.2-alpha
 
 # Libraries
 embeds.xml

--- a/Reminders.toc
+++ b/Reminders.toc
@@ -5,6 +5,10 @@
 ## SavedVariablesPerCharacter: RemindersDBPC
 ## Version: 8.0.1
 
+# Libraries
+embeds.xml
+
+# Files
 RemindersCore.lua
 RemindersReminder.lua
 RemindersUI.lua

--- a/RemindersCore.lua
+++ b/RemindersCore.lua
@@ -1,4 +1,4 @@
-Reminders = LibStub("AceAddon-3.0"):NewAddon("Reminders", "AceConsole-3.0")
+Reminders = LibStub("AceAddon-3.0"):NewAddon("Reminders", "AceConsole-3.0", "AceTimer-3.0")
 Reminders:RegisterChatCommand("reminders", "CommandProcessor")
 
 -- Globals
@@ -71,29 +71,52 @@ function Reminders:ResetAll()
 end
 
 function Reminders:OnInitialize()
-    if not _G["RemindersDBG"] then
-        _G["RemindersDBG"] = GlobalDefaults()
-    end
+    -- if not _G["RemindersDBG"] then
+    --     _G["RemindersDBG"] = GlobalDefaults()
+    -- end
 
-    if not RemindersDBPC then
-        _G["RemindersDBPC"] = PerCharacterDefaults()
-    end
+    -- if not RemindersDBPC then
+    --     _G["RemindersDBPC"] = PerCharacterDefaults()
+    -- end
 
-    RemindersDB.global = _G["RemindersDBG"]
-    RemindersDB.char   = _G["RemindersDBPC"]
+    -- RemindersDB.global = _G["RemindersDBG"]
+    -- RemindersDB.char   = _G["RemindersDBPC"]
+end
+
+function Reminders:Fire()
+    print("[ " .. date("%X") .. " ] Fired")
+end
+
+local delay = 10
+
+function CTimerFire()
+    print("[ " .. date("%X") .. " ] CTimerFired")
+
+    C_Timer.After(delay, CTimerFire)
 end
 
 function Reminders:OnEnable()
-    Reminders:DebugPrintReminders()
+    local nextFire = time() + delay
+    C_Timer.After(delay, function()
+        print("[ " .. date("%X") .. " ] CTimerFired")
 
-    Reminders:EvaluateReminders()
-    Reminders:CleanUpPlayerReminders()
+        C_Timer.After(delay, CTimerFire)
+    end)
 
-    if not GUI then GUI = Reminders:CreateUI() end
+    print("[ " .. date("%X") .. " ] It should fire in " .. delay .. " seconds (" .. nextFire .. " aka " .. date("%X", nextFire ) .. ")")
 
-    Reminders:LoadReminders(GUI)
 
-    if RemindersDB.char.debug then GUI:Show() end
+
+    -- Reminders:DebugPrintReminders()
+
+    -- Reminders:EvaluateReminders()
+    -- Reminders:CleanUpPlayerReminders()
+
+    -- if not GUI then GUI = Reminders:CreateUI() end
+
+    -- Reminders:LoadReminders(GUI)
+
+    -- if RemindersDB.char.debug then GUI:Show() end
 end
 
 function Reminders:BuildAndDisplayReminders(messages)
@@ -150,7 +173,7 @@ function Reminders:SetPlayerReminder(reminder_id, value)
     debug("[SetPlayerReminder] value = "..(value or "nil"))
     RemindersDB.char.reminders[reminder_id] = value
 
-    Reminders:DebugPrintReminders()
+    -- Reminders:DebugPrintReminders()
 end
 
 function Reminders:DeletePlayerReminder(reminder_id)
@@ -162,13 +185,13 @@ function Reminders:DebugPrintReminders()
     local reminders = RemindersDB.global.reminders
     for _, reminder in pairs(reminders) do
         local reminder = Reminders:BuildReminder(reminder)
-        chatMessage(reminder:ToString())
+        debug("[Global Reminders] " .. reminder:ToString())
     end
 
     debug("Printing profile reminders:")
     reminders = RemindersDB.char.reminders
     for key, remindAt in pairs(reminders) do
-        chatMessage("[Profile Reminders] " .. key .. " = " .. remindAt)
+        debug("[Profile Reminders] " .. key .. " = " .. remindAt)
     end
 end
 

--- a/RemindersCore.lua
+++ b/RemindersCore.lua
@@ -71,52 +71,29 @@ function Reminders:ResetAll()
 end
 
 function Reminders:OnInitialize()
-    -- if not _G["RemindersDBG"] then
-    --     _G["RemindersDBG"] = GlobalDefaults()
-    -- end
+    if not _G["RemindersDBG"] then
+        _G["RemindersDBG"] = GlobalDefaults()
+    end
 
-    -- if not RemindersDBPC then
-    --     _G["RemindersDBPC"] = PerCharacterDefaults()
-    -- end
+    if not RemindersDBPC then
+        _G["RemindersDBPC"] = PerCharacterDefaults()
+    end
 
-    -- RemindersDB.global = _G["RemindersDBG"]
-    -- RemindersDB.char   = _G["RemindersDBPC"]
-end
-
-function Reminders:Fire()
-    print("[ " .. date("%X") .. " ] Fired")
-end
-
-local delay = 10
-
-function CTimerFire()
-    print("[ " .. date("%X") .. " ] CTimerFired")
-
-    C_Timer.After(delay, CTimerFire)
+    RemindersDB.global = _G["RemindersDBG"]
+    RemindersDB.char   = _G["RemindersDBPC"]
 end
 
 function Reminders:OnEnable()
-    local nextFire = time() + delay
-    C_Timer.After(delay, function()
-        print("[ " .. date("%X") .. " ] CTimerFired")
+    Reminders:DebugPrintReminders()
 
-        C_Timer.After(delay, CTimerFire)
-    end)
+    Reminders:EvaluateReminders()
+    Reminders:CleanUpPlayerReminders()
 
-    print("[ " .. date("%X") .. " ] It should fire in " .. delay .. " seconds (" .. nextFire .. " aka " .. date("%X", nextFire ) .. ")")
+    if not GUI then GUI = Reminders:CreateUI() end
 
+    Reminders:LoadReminders(GUI)
 
-
-    -- Reminders:DebugPrintReminders()
-
-    -- Reminders:EvaluateReminders()
-    -- Reminders:CleanUpPlayerReminders()
-
-    -- if not GUI then GUI = Reminders:CreateUI() end
-
-    -- Reminders:LoadReminders(GUI)
-
-    -- if RemindersDB.char.debug then GUI:Show() end
+    if RemindersDB.char.debug then GUI:Show() end
 end
 
 function Reminders:BuildAndDisplayReminders(messages)

--- a/RemindersCore.lua
+++ b/RemindersCore.lua
@@ -84,7 +84,7 @@ function Reminders:OnInitialize()
 end
 
 function Reminders:OnEnable()
-    Reminders:DebugPrintReminders()
+    -- Reminders:DebugPrintReminders()
 
     Reminders:EvaluateReminders()
     Reminders:CleanUpPlayerReminders()

--- a/RemindersReminder.lua
+++ b/RemindersReminder.lua
@@ -81,10 +81,6 @@ function Serialize(self)
     }
 end
 
-function SetNextRemindAt(self)
-    Reminders:SetPlayerReminder(self.id, self:CalculateNextRemindAt())
-end
-
 function SetAndScheduleNextReminder(self, timeUntilnextRemindAt)
     local nextRemindAt = nil
     if timeUntilnextRemindAt then
@@ -209,7 +205,6 @@ function Reminders:BuildReminder(params)
 
     self.IsEqual = IsEqual
     self.ToString = ToString
-    -- self.SetNextRemindAt = SetNextRemindAt
     self.SetAndScheduleNextReminder = SetAndScheduleNextReminder
     self.CalculateNextRemindAt = CalculateNextRemindAt
     self.Process = Process

--- a/RemindersReminder.lua
+++ b/RemindersReminder.lua
@@ -85,11 +85,6 @@ function SetNextRemindAt(self)
     Reminders:SetPlayerReminder(self.id, self:CalculateNextRemindAt())
 end
 
-function Reminders:EvaluateReminder(reminder)
-    chatMessage("[ " .. date("%X") .. " ] EvaluateReminder called for reminder " .. reminder.id)
-    Reminders:BuildAndDisplayReminders( { reminder:Evaluate() } )
-end
-
 function SetAndScheduleNextReminder(self, timeUntilnextRemindAt)
     local nextRemindAt = nil
     if timeUntilnextRemindAt then

--- a/RemindersUI.lua
+++ b/RemindersUI.lua
@@ -136,7 +136,8 @@ local function AddReminder(newReminder)
     end
 
     newReminder:Save()
-    newReminder:SetNextRemindAt()
+    -- newReminder:SetNextRemindAt()
+    newReminder:SetAndScheduleNextReminder()
 
     Reminders:LoadReminders(GUI)
 end

--- a/RemindersUI.lua
+++ b/RemindersUI.lua
@@ -136,7 +136,6 @@ local function AddReminder(newReminder)
     end
 
     newReminder:Save()
-    -- newReminder:SetNextRemindAt()
     newReminder:SetAndScheduleNextReminder()
 
     Reminders:LoadReminders(GUI)

--- a/embeds.xml
+++ b/embeds.xml
@@ -2,6 +2,7 @@
     <Script file="Libs\LibStub\LibStub.lua"/>
 
     <Include file="Libs\AceAddon-3.0\AceAddon-3.0.xml"/>
+    <Include file="Libs\AceTimer-3.0\AceTimer-3.0.xml"/>
     <Include file="Libs\AceConsole-3.0\AceConsole-3.0.xml"/>
-    <Include file="Libs\AceDBOptions-3.0\AceDBOptions-3.0.xml"/>
+    <Include file="Libs\AceGUI-3.0\AceGUI-3.0.xml"/>
 </Ui>


### PR DESCRIPTION
This does introduce some issues like it's possible for the Reminder to now popup in the middle of you doing something (like combat).  So I need to address that in future patches.