### PR TITLE
Fix scheduling when evaluating reminders

### DIFF
--- a/RemindersReminder.lua
+++ b/RemindersReminder.lua
@@ -303,7 +303,9 @@ local function Process(self)
             shouldRemind = true
         end
 
-        self:SetAndScheduleNextReminder()
+        if shouldRemind or not remindersTimers[self.id] then
+            self:SetAndScheduleNextReminder()
+        end
 
         if shouldRemind then
             return self.message


### PR DESCRIPTION
When a reminder would get evaluated if it wasn't ready to be triggered
but already had a timer, the timer would get recreated with the full
time.  So a 30 second timer, if evaluated 10 seconds in, would not
trigger but would still get rescheduled for another 30 seconds.

This isn't an issue with daily and weekly ones (because they are at a
set time of day and not a duration).