### PR TITLE
Frames will stay put once they've been moved

### DIFF
--- a/RemindersCore.lua
+++ b/RemindersCore.lua
@@ -113,9 +113,9 @@ end
 
 function Reminders:BuildAndDisplayReminders(messages)
     if next(messages) ~= nil then
-        Reminders:ResetReminders()
+        Reminders:ResetPopup()
 
-        Reminders:DisplayReminders({
+        Reminders:DisplayPopup({
             title = "Reminder!",
             font = "Fonts\\FRIZQT__.TTF",
             fontHeight = 16,

--- a/RemindersPopup.lua
+++ b/RemindersPopup.lua
@@ -288,7 +288,7 @@ end
 
 --[[ User API ]]--
 
-function Reminders:DisplayReminders(data)
+function Reminders:DisplayPopup(data)
   if ReminderFrame == nil then
     ReminderFrame = NewFrame(data)
   end
@@ -304,6 +304,6 @@ function Reminders:DisplayReminders(data)
   end
 end
 
-function Reminders:ResetReminders()
+function Reminders:ResetPopup()
   ReminderFrame = nil
 end

--- a/RemindersPopup.lua
+++ b/RemindersPopup.lua
@@ -90,15 +90,22 @@ local default = {
   y = 0,
 }
 
-local movedPosition = nil
+local movedPosition = {
+  x = nil,
+  y = nil,
+  point = nil,
+  relPoint = nil,
+}
 
 --[[ Internal API ]]--
 
 local function StopMovingAndRecordPosition(frame)
   frame:StopMovingOrSizing()
   movedPosition = {
-    x = frame:GetTop(),
-    y = frame:GetLeft()
+    x = frame:GetLeft(),
+    y = frame:GetTop(),
+    point = "TOPLEFT",
+    relPoint = "BOTTOMLEFT",
   }
 end
 
@@ -132,7 +139,7 @@ local function UpdateFrame(frame, i)
 
   -- Frame
   frame:ClearAllPoints()
-  frame:SetPoint(data.point, data.anchor, data.relPoint, data.x, data.y)
+  frame:SetPoint((movedPosition.point or data.point), data.anchor, (movedPosition.relPoint or data.relPoint), (movedPosition.x or data.x), (movedPosition.y or data.y))
   frame:SetWidth(data.width + 16)
   frame.TitleText:SetPoint('TOP', 0, -5)
   frame.TitleText:SetText(data.title)

--- a/RemindersUI.lua
+++ b/RemindersUI.lua
@@ -108,7 +108,6 @@ end
 local function NextRemindAtSortedList(list)
     local a = {}
 
-    -- first make a new list where the key = the nextRemindAt
     for k,v in spairs(list, SortByNextRemindAt) do
         a[k] = v
     end


### PR DESCRIPTION
Or the UI was reloaded.  Maybe saving that in SavedVars is a future feature.

Fixes https://github.com/pcg79/Reminders-Addon/issues/8