### PR TITLE
Update to 9.0.1

### DIFF
--- a/Reminders.toc
+++ b/Reminders.toc
@@ -4,7 +4,7 @@
 ## Author: pcg79
 ## SavedVariables: RemindersDBG
 ## SavedVariablesPerCharacter: RemindersDBPC
-## Version: 8.2.5
+## Version: 9.0.1
 
 # Libraries
 embeds.xml

--- a/RemindersCore.lua
+++ b/RemindersCore.lua
@@ -32,7 +32,7 @@ function Reminders:ChatMessage(message)
 end
 
 function Reminders:debug(message)
-  if RemindersDB.char.debug then
+  if not RemindersDB.char or RemindersDB.char.debug then
      Reminders:ChatMessage("[ " .. date("%x %X") .. " ][debug] "..message)
   end
 end
@@ -95,6 +95,8 @@ function Reminders:ResetAll()
 end
 
 function Reminders:OnInitialize()
+    Reminders:debug("Initializing...")
+
     if not _G["RemindersDBG"] then
         _G["RemindersDBG"] = Reminders:GlobalDefaults()
     end
@@ -107,13 +109,17 @@ function Reminders:OnInitialize()
     RemindersDB.char   = _G["RemindersDBPC"]
 
     SetDefaultsIfUnset()
+    Reminders:debug("Done Initializing")
 end
 
 function Reminders:OnEnable()
+    Reminders:debug("Enabling...")
     Reminders:CreateOptions()
 
     Reminders:EvaluateReminders()
     Reminders:CleanUpPlayerReminders()
+
+    Reminders:debug("Creating UI")
 
     GUI = Reminders:CreateUI()
 
@@ -122,6 +128,7 @@ function Reminders:OnEnable()
     Reminders:LoadReminders(GUI)
 
     if RemindersDB.char.debug then GUI:Show() end
+    Reminders:debug("Done Enabling")
 end
 
 function Reminders:RegisterEvents()

--- a/RemindersUI.lua
+++ b/RemindersUI.lua
@@ -289,7 +289,7 @@ local function EditBoxOnEscapePressed(self)
 end
 
 local function CreateMessageEditBox(parentFrame)
-    local editbox = CreateFrame("EditBox", "MessageEditBox", parentFrame)
+    local editbox = CreateFrame("EditBox", "MessageEditBox", parentFrame, BackdropTemplateMixin and "BackdropTemplate")
     editbox:SetPoint("TOPLEFT", parentFrame, 50, -50)
     editbox:SetScript("OnEnterPressed", CreateReminder)
     editbox:SetScript("OnEscapePressed", EditBoxOnEscapePressed)
@@ -423,7 +423,8 @@ local function CreateConditionFrame(parentFrame)
     professionDropDown.frame:Hide()
 
 
-    local valueEditBox = CreateFrame("EditBox", "ValueEditBox", conditionFrame)
+    local valueEditBox = CreateFrame("EditBox", "ValueEditBox", conditionFrame, BackdropTemplateMixin and "BackdropTemplate")
+
     valueEditBox:SetPoint("TOPLEFT", conditionFrame, 450, 0)
     valueEditBox:SetFontObject(GameFontHighlightSmall)
     valueEditBox:SetWidth(100)


### PR DESCRIPTION
I'm back into WoW and I'm here to fix the addon.

Blizzard decided to remove the Backdrop mixin from Frames by default.  So you just need to add it in when you want to use it.